### PR TITLE
fix download_dataset path

### DIFF
--- a/download_dataset.sh
+++ b/download_dataset.sh
@@ -2,4 +2,4 @@
 
 # Downloads Iris Setosa Dataset
 echo "Download Iris Setosa Dataset @gist"
-curl -k https://gist.githubusercontent.com/netj/8836201/raw/6f9306ad21398ea43cba4f7d537619d0e07d5ae3/iris.csv -o ./output/iris.csv
+curl -k https://gist.githubusercontent.com/netj/8836201/raw/6f9306ad21398ea43cba4f7d537619d0e07d5ae3/iris.csv -o ./data/iris.csv


### PR DESCRIPTION
Adicionando esse fix para o job conseguir enxergar os dados a partir da pasta `data` ao invés de `output`